### PR TITLE
Calculate rotation and aspect ratio for special cases

### DIFF
--- a/lib/src/video_viewer.dart
+++ b/lib/src/video_viewer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
+import 'dart:io';
 
 import 'trimmer.dart';
 
@@ -64,32 +65,51 @@ class _VideoViewerState extends State<VideoViewer> {
     super.initState();
   }
 
+  int quarterTurns(double aspectRatio) {
+    if (aspectRatio > 1 || Platform.isIOS) {
+      return 0;
+    }
+
+    return 1;
+  }
+
+  double calculateAspectRatio(double originalRatio) {
+    if (originalRatio > 1 || Platform.isIOS) {
+      return originalRatio;
+    }
+
+    return 1 / originalRatio;
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = videoPlayerController;
+    final aspectRatio = controller?.value.aspectRatio;
     return controller == null
         ? Container()
         : Padding(
             padding: const EdgeInsets.all(0.0),
             child: Center(
-              child: AspectRatio(
-                aspectRatio: controller.value.aspectRatio,
-                child: controller.value.isInitialized
-                    ? Container(
-                        foregroundDecoration: BoxDecoration(
-                          border: Border.all(
-                            width: widget.borderWidth,
-                            color: widget.borderColor,
+              child: RotatedBox(
+                  quarterTurns: quarterTurns(aspectRatio ?? 1),
+                  child: AspectRatio(
+                    aspectRatio: calculateAspectRatio(aspectRatio ?? 1),
+                    child: controller.value.isInitialized
+                        ? Container(
+                            foregroundDecoration: BoxDecoration(
+                              border: Border.all(
+                                width: widget.borderWidth,
+                                color: widget.borderColor,
+                              ),
+                            ),
+                            child: VideoPlayer(controller),
+                          )
+                        : const Center(
+                            child: CircularProgressIndicator(
+                              backgroundColor: Colors.white,
+                            ),
                           ),
-                        ),
-                        child: VideoPlayer(controller),
-                      )
-                    : const Center(
-                        child: CircularProgressIndicator(
-                          backgroundColor: Colors.white,
-                        ),
-                      ),
-              ),
+                  )),
             ),
           );
   }


### PR DESCRIPTION
There is a bug in the video viewer that the video is rotated and skewed.

- only affects android
- only affects videos in portrait

With the above conditions, we can fix it by rotating the widget 90 degrees and calculating the aspect ratio as `1/originalRatio`